### PR TITLE
Issue #7: Add tests for Date REST controller

### DIFF
--- a/.github/workflows/maven-tests.yml
+++ b/.github/workflows/maven-tests.yml
@@ -1,0 +1,27 @@
+name: Maven Tests
+
+on:
+  push:
+    branches:
+      - main
+      - '7-*'
+      - 'feature/**'
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Run tests
+        run: mvn -B test

--- a/src/test/java/com/example/demo/DateControllerTest.java
+++ b/src/test/java/com/example/demo/DateControllerTest.java
@@ -1,0 +1,28 @@
+package com.example.demo;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class DateControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void messageEndpointReturnsCurrentDateInMessageKey() throws Exception {
+        mockMvc.perform(get("/message"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value(LocalDate.now().toString()));
+    }
+}


### PR DESCRIPTION
Closes #7

- adds test for `/message` endpoint
- verifies JSON key `message` contains current date
- adds GitHub Actions pipeline for Maven tests